### PR TITLE
feat: интеграция с auth-service

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,11 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.42'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/auth/AuthServiceClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/auth/AuthServiceClient.java
@@ -1,0 +1,45 @@
+package com.itmentorcommunityplatform.dataimporter.auth;
+
+import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
+import com.itmentorcommunityplatform.dataimporter.dto.UserUpsertRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthServiceClient {
+
+    private final DataImporterProperties props;
+    private final WebClient webClient;
+
+    public void upsertUser(UserUpsertRequestDto request) {
+        String url = props.getAuthServiceBaseUrl() + "/api/auth/internal/user";
+        try {
+            webClient.post()
+                    .uri(url)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .bodyValue(request)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block(Duration.ofSeconds(10));
+            log.info("Successfully upserted user in Auth Service: telegramId={}, roles={}",
+                    request.telegramUserId(), request.roles());
+        } catch (WebClientResponseException wcre) {
+            log.error("Auth Service returned error. status={}, body={}, telegramId={}",
+                    wcre.getStatusCode().value(), wcre.getResponseBodyAsString(), request.telegramUserId());
+            throw wcre;
+        } catch (Exception ex) {
+            log.error("Failed to call Auth Service for telegramId={}, error={}",
+                    request.telegramUserId(), ex.getMessage(), ex);
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
@@ -13,4 +13,5 @@ public class DataImporterProperties {
     private String spreadsheetId;
     private String sheetRange;
     private List<Long> adminIds;
+    private String authServiceBaseUrl;
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/WebClientConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.itmentorcommunityplatform.dataimporter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/UserUpsertRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/UserUpsertRequestDto.java
@@ -1,0 +1,15 @@
+package com.itmentorcommunityplatform.dataimporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UserUpsertRequestDto(
+        @NotNull
+        @JsonProperty("telegram_user_id")
+        Long telegramUserId,
+        @NotEmpty
+        List<String> roles
+) {}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
@@ -1,7 +1,9 @@
 package com.itmentorcommunityplatform.dataimporter.service;
 
+import com.itmentorcommunityplatform.dataimporter.auth.AuthServiceClient;
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
 import com.itmentorcommunityplatform.dataimporter.dto.UserImportDto;
+import com.itmentorcommunityplatform.dataimporter.dto.UserUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
 import com.itmentorcommunityplatform.dataimporter.metrics.ImportMetrics;
 import com.itmentorcommunityplatform.dataimporter.model.UserRole;
@@ -22,6 +24,7 @@ public class UserImportService {
     private final GoogleSheetsClient googleSheetsClient;
     private final DataImporterProperties props;
     private final ImportMetrics importMetrics;
+    private final AuthServiceClient authServiceClient;
 
     private final ExecutorService executor =
             Executors.newSingleThreadExecutor(r -> new Thread(r, "user-import-thread"));
@@ -67,9 +70,18 @@ public class UserImportService {
                         ? UserRole.ADMIN
                         : UserRole.STUDENT;
                 UserImportDto dto = new UserImportDto(tgId, role.name());
-                log.info("Imported user: telegramId={}, role={}", dto.getTelegramId(), dto.getRole());
-                importMetrics.getImportSuccessCounter().increment();
-                processed++;
+                UserUpsertRequestDto userUpsertRequestDto = new UserUpsertRequestDto(
+                        dto.getTelegramId(),
+                        List.of(dto.getRole())
+                );
+                try {
+                    authServiceClient.upsertUser(userUpsertRequestDto);
+                    importMetrics.getImportSuccessCounter().increment();
+                    processed++;
+                    log.info("Imported user: telegramId={}, role={}", dto.getTelegramId(), dto.getRole());
+                } catch (Exception ex) {
+                    importMetrics.getImportErrorCounter().increment();
+                }
             }
             log.info("Users import finished. Total processed users: {}", processed);
 

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
@@ -2,7 +2,6 @@ package com.itmentorcommunityplatform.dataimporter.service;
 
 import com.itmentorcommunityplatform.dataimporter.auth.AuthServiceClient;
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
-import com.itmentorcommunityplatform.dataimporter.dto.UserImportDto;
 import com.itmentorcommunityplatform.dataimporter.dto.UserUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
 import com.itmentorcommunityplatform.dataimporter.metrics.ImportMetrics;
@@ -66,21 +65,22 @@ public class UserImportService {
                     importMetrics.getImportErrorCounter().increment();
                     continue;
                 }
-                UserRole role = (props.getAdminIds() != null && props.getAdminIds().contains(tgId))
-                        ? UserRole.ADMIN
-                        : UserRole.STUDENT;
-                UserImportDto dto = new UserImportDto(tgId, role.name());
-                UserUpsertRequestDto userUpsertRequestDto = new UserUpsertRequestDto(
-                        dto.getTelegramId(),
-                        List.of(dto.getRole())
+                boolean isAdmin = props.getAdminIds() != null && props.getAdminIds().contains(tgId);
+                List<String> rolesToSend = isAdmin
+                        ? List.of(UserRole.ADMIN.name(), UserRole.STUDENT.name())
+                        : List.of(UserRole.STUDENT.name());
+                UserUpsertRequestDto req = new UserUpsertRequestDto(
+                        tgId,
+                        rolesToSend
                 );
                 try {
-                    authServiceClient.upsertUser(userUpsertRequestDto);
+                    authServiceClient.upsertUser(req);
                     importMetrics.getImportSuccessCounter().increment();
                     processed++;
-                    log.info("Imported user: telegramId={}, role={}", dto.getTelegramId(), dto.getRole());
+                    log.info("Imported user: telegramId={}, roles={}", tgId, rolesToSend);
                 } catch (Exception ex) {
                     importMetrics.getImportErrorCounter().increment();
+                    log.error("Failed to import user telegramId={}", tgId, ex);
                 }
             }
             log.info("Users import finished. Total processed users: {}", processed);

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -10,6 +10,7 @@ dataimporter:
     spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
     sheet-range: "Telegram аккаунты студентов!B2:B"
     admin-ids: []
+    auth-service-base-url: "http://localhost:8081"
 
 management:
     endpoint:

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -10,6 +10,7 @@ dataimporter:
   spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
   sheet-range: "Telegram аккаунты студентов!B2:B"
   admin-ids: []
+  auth-service-base-url: "http://auth-service:8080"
 
 management:
     endpoint:


### PR DESCRIPTION
Интеграция с auth-service через WebClient для импорта пользователей
- добавлен WebClient для HTTP-запросов к Auth Service
- реализован вызов POST /api/auth/internal/user для каждого импортируемого пользователя
- обновлены конфигурационные файлы (auth-service-url для разных профилей)
