### PR TITLE
feat: добавляет сборку multi-arch образов docker

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Enable QEMU Emulation for Multi-Arch Builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Initialize Docker Buildx for Multi-Arch Builds
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -33,12 +39,14 @@ jobs:
         run: |
           RAW_NAME=${GITHUB_REF_NAME}
           SAFE_NAME=$(echo "$RAW_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+          SAFE_NAME=$(echo "$SAFE_NAME" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
           echo "name=$SAFE_NAME" >> $GITHUB_OUTPUT
+          echo "repo=$REPO_NAME" >> $GITHUB_OUTPUT
 
-      - name: Build Docker image
+      - name: Build and push multi-arch Docker image
         run: |
-          docker build -t ghcr.io/${{ github.repository }}/data-importer:${{ steps.branch.outputs.name }} .
-
-      - name: Push Docker image
-        run: |
-          docker push ghcr.io/${{ github.repository }}/data-importer:${{ steps.branch.outputs.name }}
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/${{ steps.branch.outputs.repo }}/data-importer:${{ steps.branch.outputs.name }} \
+            --push .


### PR DESCRIPTION
Конфигурирует GitHub Actions для сборки и публикации Docker-образов для архитектур linux/amd64 и linux/arm64 с использованием QEMU и Docker Buildx.
Добавляет к логике тегирования образов приведение к нижнему регистру, т.к. образы в ghcr.io могут содержать символы только в нижнем регистре.

Результат проверки:
```sh
docker buildx imagetools inspect ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21
```
```
Name:      ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:ed85d77e61f99009bbf8075ac01bb46b1dd49151cb04ecc5b3b2b1ca8fccd04d
           
Manifests: 
  Name:        ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21@sha256:552716cb0dd9cdb88688953068a7adafe48e2141580456a80e78d7387094b90f
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21@sha256:5fb6db5650f012be26a39c7e09c4eb6f92d4a80a08a100559e0572a1a58b3343
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21@sha256:e09e7f09cc5c9ead9b09479728d875e8f29d6e257665c0fd598785e0a33741f5
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:552716cb0dd9cdb88688953068a7adafe48e2141580456a80e78d7387094b90f
    vnd.docker.reference.type:   attestation-manifest
               
  Name:        ghcr.io/it-mentor-community-platform/data-importer/data-importer:feature-build-multi-arch-docker-image-21@sha256:149e070deb76a0b2cc02a17fed999676488fd732ddf03a2df29d47a6b6cc1a57
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:5fb6db5650f012be26a39c7e09c4eb6f92d4a80a08a100559e0572a1a58b3343
    vnd.docker.reference.type:   attestation-manifest
```

Когда в workflow включен `id-token: write` Docker Buildx автоматически генерирует attestation-манифесты - те у которых `Platform: unknown/unknown`. Это не рабочие контейнеры, а метаданные, которые подтверждают происхождение образа. 