### PR TITLE
Feature endpoint for import projects from google spreadsheet 28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,22 +20,35 @@ repositories {
 }
 
 dependencies {
+    // Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Google Sheets / Auth
     implementation 'com.google.api-client:google-api-client:2.7.2'
     implementation 'com.google.apis:google-api-services-sheets:v4-rev20250616-2.0.0'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.40.0'
-    implementation 'org.projectlombok:lombok:1.18.42'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Metrics
     implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 
+    // Lombok
+    implementation 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
+
+    // Dev
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/httpRequests/projects-import.http
+++ b/httpRequests/projects-import.http
@@ -1,18 +1,18 @@
 ### Successful start - admin role
-POST http://localhost:8080/api/data-importer/start-profiles-import
+POST http://localhost:8080/api/data-importer/start-projects-import
 Content-Type: application/json
 X-User-Roles: ADMIN
 
 ### Missing roles header -> 403
-POST http://localhost:8080/api/data-importer/start-profiles-import
+POST http://localhost:8080/api/data-importer/start-projects-import
 Content-Type: application/json
 
 ### Not admin -> 403
-POST http://localhost:8080/api/data-importer/start-profiles-import
+POST http://localhost:8080/api/data-importer/start-projects-import
 Content-Type: application/json
 X-User-Roles: STUDENT
 
 ### Multiple roles -> admin included
-POST http://localhost:8080/api/data-importer/start-profiles-import
+POST http://localhost:8080/api/data-importer/start-projects-import
 Content-Type: application/json
 X-User-Roles: STUDENT,ADMIN

--- a/httpRequests/users-import.http
+++ b/httpRequests/users-import.http
@@ -1,19 +1,19 @@
 ### Successful start - admin role
-POST http://localhost:8082/api/data-importer/start-users-import
+POST http://localhost:8080/api/data-importer/start-users-import
 Content-Type: application/json
 X-User-Roles: ADMIN
 
 ### Missing roles header -> 403
-POST http://localhost:8082/api/data-importer/start-users-import
+POST http://localhost:8080/api/data-importer/start-users-import
 Content-Type: application/json
 
 ### Not admin -> 403
-POST http://localhost:8082/api/data-importer/start-users-import
+POST http://localhost:8080/api/data-importer/start-users-import
 Content-Type: application/json
 X-User-Roles: STUDENT
 
 ### Multiple roles -> admin included
-POST http://localhost:8082/api/data-importer/start-users-import
+POST http://localhost:8080/api/data-importer/start-users-import
 Content-Type: application/json
 X-User-Roles: STUDENT,ADMIN
 

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
@@ -11,7 +11,8 @@ import java.util.List;
 @Data
 public class DataImporterProperties {
     private String spreadsheetId;
-    private String sheetRange;
+    private String sheetRangeTelegramAccounts;
+    private String sheetRangeProjects;
     private List<Long> adminIds;
     private String authServiceBaseUrl;
     private String profileServiceBaseUrl;

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProjectImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProjectImportController.java
@@ -1,0 +1,35 @@
+package com.itmentorcommunityplatform.dataimporter.controller;
+
+import com.itmentorcommunityplatform.dataimporter.controller.api.ProjectImportApi;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
+import com.itmentorcommunityplatform.dataimporter.service.ProjectImportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/data-importer")
+@RequiredArgsConstructor
+public class ProjectImportController implements ProjectImportApi {
+    private final ProjectImportService projectImportService;
+
+    @Override
+    @PostMapping("/start-projects-import")
+    public ResponseEntity<?> startProjectImport(
+            @RequestHeader(value = "X-User-Roles", required = false) List<String> roles) {
+
+        if (roles == null || roles.stream().noneMatch(r -> r.equalsIgnoreCase("ADMIN"))) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ErrorResponseDto("Access denied: missing ADMIN role in X-User-Roles header"));
+        }
+        projectImportService.startImportAsync();
+        return ResponseEntity.ok(new ImportStartResponseDto("import_started"));
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/api/ProjectImportApi.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/api/ProjectImportApi.java
@@ -1,0 +1,60 @@
+package com.itmentorcommunityplatform.dataimporter.controller.api;
+
+import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Project Import", description = "API for managing project imports")
+public interface ProjectImportApi {
+
+    @Operation(
+            summary = "Starting project import",
+            description = "Asynchronously starts the process of reading the Google Spreadsheet and creating/updating projects in the Project Service."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Import started successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ImportStartResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access is denied (there is no ADMIN role)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            )
+    })
+    ResponseEntity<?> startProjectImport(
+            @Parameter(
+                    name = "X-User-Roles",
+                    in = ParameterIn.HEADER,
+                    description = "The list of user roles. The ADMIN role is required.",
+                    required = true,
+                    schema = @Schema(type = "string", example = "ADMIN")
+            )
+            List<String> roles
+    );
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/request/ProjectUpsertRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/request/ProjectUpsertRequestDto.java
@@ -1,0 +1,10 @@
+package com.itmentorcommunityplatform.dataimporter.dto.request;
+
+public record ProjectUpsertRequestDto(
+        Long authorTelegramUserId,
+        String githubRepositoryUrl,
+        String programmingLanguage,
+        String roadmapProject,
+        Long addedTimestamp,
+        String projectSourceType) {
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/response/ProfileByGithubResponseDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/response/ProfileByGithubResponseDto.java
@@ -1,0 +1,5 @@
+package com.itmentorcommunityplatform.dataimporter.dto.response;
+
+public record ProfileByGithubResponseDto(Long telegramUserId, ProfileDetailsDto details) {
+}
+

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/response/ProfileDetailsDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/response/ProfileDetailsDto.java
@@ -1,0 +1,11 @@
+package com.itmentorcommunityplatform.dataimporter.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProfileDetailsDto {
+    private String githubProfile;
+    private String telegramUrl;
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
@@ -61,9 +61,9 @@ public class GoogleSheetsClient {
         }
     }
 
-    public List<List<Object>> readSheet() throws IOException {
+    public List<List<Object>> readSheet(String spreedSheetRange) throws IOException {
         String spreadsheetId = props.getSpreadsheetId();
-        String range = props.getSheetRange();
+        String range = spreedSheetRange;
         log.debug("Reading Google Sheet: id={}, range={}", spreadsheetId, range);
         ValueRange response = sheetsService.spreadsheets().values()
                 .get(spreadsheetId, range)

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
@@ -72,9 +72,7 @@ public class ServiceHttpClient {
         String url = props.getProfileServiceBaseUrl() + "/api/profile/internal/profile/by-github-profile-url";
         try {
             ProfileByGithubResponseDto response = webClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .queryParam("url", githubProfileUrl)
-                            .build())
+                    .uri(url + "?url=" + githubProfileUrl)
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .retrieve()
                     .bodyToMono(ProfileByGithubResponseDto.class)
@@ -86,7 +84,7 @@ public class ServiceHttpClient {
         } catch (WebClientResponseException wcre) {
             log.error("Profile Service returned error. status={}, body={}, githubUrl={}",
                     wcre.getStatusCode().value(), wcre.getResponseBodyAsString(), githubProfileUrl);
-            return null; // или throw, в зависимости от логики
+            throw wcre;
         } catch (Exception ex) {
             log.error("Failed to fetch profile for githubUrl={}, error={}",
                     githubProfileUrl, ex.getMessage(), ex);

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
@@ -3,6 +3,7 @@ package com.itmentorcommunityplatform.dataimporter.httpclient;
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
 import com.itmentorcommunityplatform.dataimporter.dto.request.ProfileUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.dto.request.UserUpsertRequestDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ProfileByGithubResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -16,7 +17,7 @@ import java.time.Duration;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class InterServiceHttpClient {
+public class ServiceHttpClient {
 
     private final DataImporterProperties props;
     private final WebClient webClient;
@@ -64,6 +65,32 @@ public class InterServiceHttpClient {
             log.error("Failed to call Profile Service for telegramId={}, error={}",
                     request.telegramUserId(), ex.getMessage(), ex);
             throw new RuntimeException(ex);
+        }
+    }
+
+    public ProfileByGithubResponseDto getProfileByGithubUrl(String githubProfileUrl) {
+        String url = props.getProfileServiceBaseUrl() + "/api/profile/internal/profile/by-github-profile-url";
+        try {
+            ProfileByGithubResponseDto response = webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .queryParam("url", githubProfileUrl)
+                            .build())
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .retrieve()
+                    .bodyToMono(ProfileByGithubResponseDto.class)
+                    .block(Duration.ofSeconds(10));
+
+            log.info("Successfully fetched profile for GitHub URL: {}", githubProfileUrl);
+            return response;
+
+        } catch (WebClientResponseException wcre) {
+            log.error("Profile Service returned error. status={}, body={}, githubUrl={}",
+                    wcre.getStatusCode().value(), wcre.getResponseBodyAsString(), githubProfileUrl);
+            return null; // или throw, в зависимости от логики
+        } catch (Exception ex) {
+            log.error("Failed to fetch profile for githubUrl={}, error={}",
+                    githubProfileUrl, ex.getMessage(), ex);
+            return null;
         }
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/metrics/MetricsConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/metrics/MetricsConfig.java
@@ -54,4 +54,27 @@ public class MetricsConfig {
                 .publishPercentileHistogram()
                 .register(registry);
     }
+
+    @Bean
+    public Counter projectImportSuccessCounter(MeterRegistry registry) {
+        return Counter.builder("data_importer_projects_success_total")
+                .description("Total successfully imported projects")
+                .register(registry);
+    }
+
+    @Bean
+    public Counter projectImportErrorCounter(MeterRegistry registry) {
+        return Counter.builder("data_importer_projects_error_total")
+                .description("Total failed project imports")
+                .register(registry);
+    }
+
+    @Bean
+    public Timer projectImportDurationTimer(MeterRegistry registry) {
+        return Timer.builder("data_importer_projects_import_duration_seconds")
+                .description("Time taken to complete projects import in seconds")
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .publishPercentileHistogram()
+                .register(registry);
+    }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProfileImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProfileImportService.java
@@ -1,8 +1,9 @@
 package com.itmentorcommunityplatform.dataimporter.service;
 
+import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
 import com.itmentorcommunityplatform.dataimporter.dto.request.ProfileUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
-import com.itmentorcommunityplatform.dataimporter.httpclient.InterServiceHttpClient;
+import com.itmentorcommunityplatform.dataimporter.httpclient.ServiceHttpClient;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,8 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ProfileImportService {
     private final GoogleSheetsClient googleSheetsClient;
-    private final InterServiceHttpClient httpClient;
+    private final ServiceHttpClient httpClient;
+    private final DataImporterProperties properties;
 
     private final Counter profilesImportSuccessCounter;
     private final Counter profilesImportErrorCounter;
@@ -41,7 +43,7 @@ public class ProfileImportService {
     private void doImport() {
         log.info("Starting profile import (async)...");
         try {
-            List<List<Object>> rows = googleSheetsClient.readSheet();
+            List<List<Object>> rows = googleSheetsClient.readSheet(properties.getSheetRangeTelegramAccounts());
             if (rows.isEmpty()) {
                 log.info("Sheet returned empty result.");
                 return;

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectImportService.java
@@ -1,0 +1,153 @@
+package com.itmentorcommunityplatform.dataimporter.service;
+
+import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
+import com.itmentorcommunityplatform.dataimporter.dto.request.ProjectUpsertRequestDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ProfileByGithubResponseDto;
+import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
+import com.itmentorcommunityplatform.dataimporter.httpclient.ServiceHttpClient;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PreDestroy;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProjectImportService {
+    private final GoogleSheetsClient googleSheetsClient;
+    private final ServiceHttpClient httpClient;
+    private final DataImporterProperties properties;
+
+    private final Counter projectImportSuccessCounter;
+    private final Counter projectImportErrorCounter;
+    private final Timer projectImportDurationTimer;
+
+    private static final String PROJECT_SOURCE_TYPE = "DATA_IMPORTER";
+
+    private static final String[] RU_MONTHS = {
+            "январь", "февраль", "март", "апрель", "май", "июнь", "июль",
+            "август", "сентябрь", "октябрь", "ноябрь", "декабрь"
+    };
+
+    private final ExecutorService executor =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, "project-import-thread"));
+
+    public void startImportAsync() {
+        executor.submit(this::doImportMeasured);
+    }
+
+    private void doImportMeasured() {
+        projectImportDurationTimer.record(this::doImport);
+    }
+
+    private void doImport() {
+        log.info("Starting project import (async)...");
+        try {
+            List<List<Object>> rows = googleSheetsClient.readSheet(properties.getSheetRangeProjects());
+            if (rows.isEmpty()) {
+                log.info("Sheet returned empty result.");
+                return;
+            }
+
+            Set<String> processedProjects = new HashSet<>();
+            int processed = 0;
+            int skippedDuplicates = 0;
+
+            for (int i = 0; i < rows.size(); i++) {
+                List<Object> row = rows.get(i);
+                if (row == null || row.isEmpty()) {
+                    log.warn("Skipping empty row at index {}", i);
+                    continue;
+                }
+
+                String addedTimestamp = String.valueOf(row.get(0)).trim();
+                String roadmapProject = String.valueOf(row.get(1)).trim();
+                String programmingLanguage = String.valueOf(row.get(2)).trim();
+                String githubRepositoryLink = String.valueOf(row.get(4)).trim();
+                String githubProfileLink = String.valueOf(row.get(6)).trim();
+
+                if (githubRepositoryLink.isEmpty() && githubProfileLink.isEmpty()) {
+                    log.warn("Skipping row with no GitHub repository or profile link at index {}", i);
+                    continue;
+                }
+
+                if (processedProjects.contains(githubRepositoryLink)) {
+                    skippedDuplicates++;
+                    log.debug("Skipping duplicate project: {} at row {}", githubRepositoryLink, i);
+                    continue;
+                }
+
+                ProfileByGithubResponseDto profile = httpClient
+                        .getProfileByGithubUrl(githubProfileLink);
+
+                if (profile == null || profile.telegramUserId() == null) {
+                    log.warn("Profile not found or invalid Telegram User ID for GitHub URL: {} at row {}",
+                            githubProfileLink, i);
+                    continue;
+                }
+
+
+                var requestDto = new ProjectUpsertRequestDto(
+                        profile.telegramUserId(),
+                        githubRepositoryLink,
+                        programmingLanguage,
+                        roadmapProject,
+                        parseTimestamp(addedTimestamp),
+                        PROJECT_SOURCE_TYPE
+                );
+
+                try {
+                    //  httpClient.upsertProject(requestDto);
+                    processedProjects.add(githubRepositoryLink);
+                    projectImportSuccessCounter.increment();
+                    processed++;
+                    log.info("Imported project: repo={}, profile={}, roadmap={}",
+                            githubRepositoryLink, githubProfileLink, roadmapProject);
+                } catch (Exception ex) {
+                    projectImportErrorCounter.increment();
+                    log.error("Failed to import project at row {}: repo={}", i, githubRepositoryLink, ex);
+                }
+            }
+            log.info("Project import finished. Total processed: {}. Skipped duplicates: {}",
+                    processed, skippedDuplicates);
+
+        } catch (Exception e) {
+            log.error("Failed to import projects", e);
+            projectImportErrorCounter.increment();
+        }
+    }
+
+
+    private Long parseTimestamp(String dateStr) {
+        if (dateStr.isEmpty()) return null;
+
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("MMMM, yyyy", new Locale("ru"));
+            sdf.setDateFormatSymbols(new java.text.DateFormatSymbols() {{
+                setMonths(RU_MONTHS);
+            }});
+            Date date = sdf.parse(dateStr.toLowerCase()); // lower-case для надёжности
+            return date.getTime();
+        } catch (Exception e) {
+            log.warn("Failed to parse date '{}': {}", dateStr, e.getMessage());
+            return System.currentTimeMillis();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        executor.shutdownNow();
+    }
+
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
@@ -3,7 +3,7 @@ package com.itmentorcommunityplatform.dataimporter.service;
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
 import com.itmentorcommunityplatform.dataimporter.dto.request.UserUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
-import com.itmentorcommunityplatform.dataimporter.httpclient.InterServiceHttpClient;
+import com.itmentorcommunityplatform.dataimporter.httpclient.ServiceHttpClient;
 import com.itmentorcommunityplatform.dataimporter.model.UserRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
@@ -24,8 +24,8 @@ import java.util.concurrent.Executors;
 public class UserImportService {
 
     private final GoogleSheetsClient googleSheetsClient;
-    private final DataImporterProperties props;
-    private final InterServiceHttpClient httpClient;
+    private final DataImporterProperties properties;
+    private final ServiceHttpClient httpClient;
 
     private final Counter usersImportSuccessCounter;
     private final Counter usersImportErrorCounter;
@@ -45,7 +45,7 @@ public class UserImportService {
     private void doImport() {
         log.info("Starting users import (async)...");
         try {
-            List<List<Object>> rows = googleSheetsClient.readSheet();
+            List<List<Object>> rows = googleSheetsClient.readSheet(properties.getSheetRangeTelegramAccounts());
             if (rows.isEmpty()) {
                 log.info("Sheet returned empty result.");
                 return;
@@ -77,7 +77,7 @@ public class UserImportService {
                     skippedDuplicates++;
                     continue;
                 }
-                boolean isAdmin = props.getAdminIds() != null && props.getAdminIds().contains(tgId);
+                boolean isAdmin = properties.getAdminIds() != null && properties.getAdminIds().contains(tgId);
                 List<String> rolesToSend = isAdmin
                         ? List.of(UserRole.ADMIN.name(), UserRole.STUDENT.name())
                         : List.of(UserRole.STUDENT.name());

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -3,15 +3,16 @@ spring:
         activate:
             on-profile: ide
 
-server:
-    port: 8082
+
 
 dataimporter:
     spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
-    sheet-range: "Telegram аккаунты студентов!A2:C"
+    sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
+    sheet-range-projects: "Projects!A3:I"
     admin-ids: []
     auth-service-base-url: "http://localhost:8081"
     profile-service-base-url: "http://localhost:8083"
+    project-service-base-url: "http//localhost:8084"
 
 management:
     endpoint:

--- a/src/test/java/DataImporterApplicationTests.java
+++ b/src/test/java/DataImporterApplicationTests.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class DataImporterApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/itmentorcommunityplatform/dataimporter/projectImport/ProjectImportServiceTest.java
+++ b/src/test/java/com/itmentorcommunityplatform/dataimporter/projectImport/ProjectImportServiceTest.java
@@ -1,0 +1,87 @@
+package com.itmentorcommunityplatform.dataimporter.projectImport;
+
+import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ProfileByGithubResponseDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ProfileDetailsDto;
+import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
+import com.itmentorcommunityplatform.dataimporter.httpclient.ServiceHttpClient;
+import com.itmentorcommunityplatform.dataimporter.service.ProjectImportService;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectImportServiceTest {
+
+    @Mock
+    GoogleSheetsClient sheetsClient;
+    @Mock
+    ServiceHttpClient httpClient;
+    @Mock
+    DataImporterProperties properties;
+    @Mock
+    Counter projectImportSuccessCounter;
+    @Mock
+    Counter projectImportErrorCounter;
+    @Mock
+    Timer projectImportDurationTimer;
+
+    ProjectImportService service;
+
+    @BeforeEach
+    void setUp() {
+        when(properties.getSheetRangeProjects()).thenReturn("dummy-range");
+
+        service = new ProjectImportService(
+                sheetsClient,
+                httpClient,
+                properties,
+                projectImportSuccessCounter,
+                projectImportErrorCounter,
+                projectImportDurationTimer
+        );
+    }
+
+    @Test
+    void testDoImportPrivate() throws Exception {
+        List<List<Object>> rows = List.of(
+                List.of("Июнь, 2021", "simulation", "Kotlin", "", "https://github.com/anelfer/simulation2077", "", "https://github.com/anelfer"),
+                List.of("Ноябрь, 2021", "simulation", "PHP", "", "https://github.com/BorBoris23/WarhammerWB", "", "https://github.com/BorBoris23"),
+                List.of("Апрель, 2022", "tennis-scoreboard", "Java", "", "https://github.com/Jollykai/tennisTableboard", "", "https://github.com/Jollykai")
+        );
+        when(sheetsClient.readSheet("dummy-range")).thenReturn(rows);
+
+        when(httpClient.getProfileByGithubUrl("https://github.com/anelfer"))
+                .thenReturn(new ProfileByGithubResponseDto(1L,
+                        new ProfileDetailsDto("https://github.com/anelfer", "https://t.me/user1")));
+        when(httpClient.getProfileByGithubUrl("https://github.com/BorBoris23"))
+                .thenReturn(new ProfileByGithubResponseDto(2L,
+                        new ProfileDetailsDto("https://github.com/BorBoris23", "https://t.me/user2")));
+        when(httpClient.getProfileByGithubUrl("https://github.com/Jollykai"))
+                .thenReturn(new ProfileByGithubResponseDto(3L,
+                        new ProfileDetailsDto("https://github.com/Jollykai", "https://t.me/user3")));
+
+        Method doImportMethod = ProjectImportService.class.getDeclaredMethod("doImport");
+        doImportMethod.setAccessible(true);
+        doImportMethod.invoke(service);
+
+        verify(projectImportSuccessCounter, times(3)).increment();
+        verify(projectImportErrorCounter, never()).increment();
+
+        verify(httpClient).getProfileByGithubUrl("https://github.com/anelfer");
+        verify(httpClient).getProfileByGithubUrl("https://github.com/BorBoris23");
+        verify(httpClient).getProfileByGithubUrl("https://github.com/Jollykai");
+    }
+}


### PR DESCRIPTION
### Что сделано в Data Importer

**Добавлен полный импорт проектов из Google Sheets:**
- Читает строки с данными (дата, язык, репозиторий, профиль GitHub,дата публикации)
- Для каждого проекта делает запрос в Profile Service по GitHub профилю автора
- Получает telegram_user_id и telegram_url, формирует ProjectUpsertRequestDto
- Парсит русские даты "Июнь, 2022" → Unix timestamp

**Мониторинг и логи:**
- projectImportSuccessCounter — успешно импортированные проекты
- projectImportErrorCounter — ошибки импорта 
- Логи с row index, GitHub URL, статусами ошибок
- Асинхронный запуск через ExecutorService

**Тесты проверяют:**
- Парсинг дат → timestamp
- Вызов Profile Service с правильными URL
- Формирование DTO с верными значениями
- Обработку null ответов

**Инфраструктура:**
- Порт изменён на 8080 (application-ide.yaml + HTTP тесты)
- Swagger/OpenAPI для всех эндпоинтов
- Константа PROJECT_SOURCE_TYPE = "DATA_IMPORTER"
