### PR TITLE
feat: добавлен Kafka consumer для обработки событий создания проектов

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // Lombok
     implementation 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/KafkaStartupValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/KafkaStartupValidator.java
@@ -1,0 +1,42 @@
+package com.itmentorcommunityplatform.dataimporter.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaStartupValidator {
+
+    private final KafkaProperties kafkaProperties;
+    private static final String REQUIRED_TOPIC = "projects.project.created";
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void validateKafkaConnection() {
+        log.info("Validating Kafka connection and topic existence: {}", REQUIRED_TOPIC);
+        try (AdminClient client = AdminClient.create(kafkaProperties.buildAdminProperties(null))) {
+            ListTopicsOptions options = new ListTopicsOptions();
+            options.timeoutMs(5000);
+            Set<String> topics = client.listTopics(options).names().get(5, TimeUnit.SECONDS);
+            if (!topics.contains(REQUIRED_TOPIC)) {
+                log.error("CRITICAL: Required Kafka topic '{}' is missing! Available topics: {}", REQUIRED_TOPIC, topics);
+                throw new IllegalStateException("Required Kafka topic missing: " + REQUIRED_TOPIC);
+            }
+            log.info("Kafka validation successful. Topic '{}' exists.", REQUIRED_TOPIC);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.error("CRITICAL: Could not connect to Kafka or timeout occurred during validation.", e);
+            throw new IllegalStateException("Could not connect to Kafka broker", e);
+        }
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/event/ProjectCreatedEvent.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/event/ProjectCreatedEvent.java
@@ -1,0 +1,31 @@
+package com.itmentorcommunityplatform.dataimporter.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ProjectCreatedEvent {
+
+    @JsonProperty("author_telegram_user_id")
+    private Long authorTelegramUserId;
+
+    @JsonProperty("author_telegram_profile_url")
+    private String authorTelegramProfileUrl;
+
+    @JsonProperty("github_repository_url")
+    private String githubRepositoryUrl;
+
+    @JsonProperty("programming_language")
+    private String programmingLanguage;
+
+    @JsonProperty("roadmap_project")
+    private String roadmapProject;
+
+    @JsonProperty("added_timestamp")
+    private Long addedTimestamp;
+
+    @JsonProperty("project_source_type")
+    private String projectSourceType;
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectEventsListener.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectEventsListener.java
@@ -1,0 +1,28 @@
+package com.itmentorcommunityplatform.dataimporter.service;
+
+import com.itmentorcommunityplatform.dataimporter.dto.event.ProjectCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProjectEventsListener {
+
+    private static final String DATA_IMPORTER_SOURCE = "DATA_IMPORTER";
+
+    @KafkaListener(
+            topics = "projects.project.created",
+            groupId = "data-importer-cg",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void listenProjectCreated(ProjectCreatedEvent event) {
+        if (DATA_IMPORTER_SOURCE.equalsIgnoreCase(event.getProjectSourceType())) {
+            log.debug("Skipping project event from source: {}", event.getProjectSourceType());
+            return;
+        }
+        log.info("Received new project event: {}", event);
+    }
+}

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -3,6 +3,8 @@ spring:
         activate:
             on-profile: ide
 
+    kafka:
+        bootstrap-servers: localhost:29092
 
 
 dataimporter:

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -3,6 +3,9 @@ spring:
     activate:
       on-profile: local-stack
 
+  kafka:
+    bootstrap-servers: kafka:9092
+
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,22 @@
 spring:
   application:
     name: data-importer
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: data-importer-cg
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.value.default.type: com.itmentorcommunityplatform.dataimporter.dto.event.ProjectCreatedEvent
+        spring.json.use.type.headers: false
+    listener:
+      missing-topics-fatal: true
+
 logging:
     level:
       root: INFO


### PR DESCRIPTION
- Добавлена конфигурация Kafka с аварийным завершением при проблемах
- Создан KafkaStartupValidator для проверки подключения к Kafka при старте сервиса
- Реализован consumer ProjectEventsListener для топика projects.project.created
- Логирование полученных событий с типом не DATA_IMPORTER