### PR TITLE
Импорт гарантированных ревью из Google Spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ docker-compose.override.yml
 *.secret
 *.key
 src/main/resources/credentials.json
-src/main/resources/credentials.json
 
 HELP.md
 !.mvn/wrapper/maven-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@
 - [Бизнес аналитика - импорт данных](https://github.com/it-mentor-community-platform/meta/blob/main/business-analytics/functionality/data-import.md)
 - [Системная аналитика - импорт данных](https://github.com/it-mentor-community-platform/meta/blob/main/system-analytics/functionality/data-import.md)
 
-   
-### Локальный запуск и тестирование
-1. Для сервиса Data Importer необходим файл credentials.json(его можно получить в Secrets в гитхабе или запроси его у тимлида) 
-   - Скопируй его в src/main/resources
-   - В корне проекта создай файл .env:
+## Локальный запуск и тестирование
+1. Для сервиса Data Importer необходимо получить содержимое credentials.json (из GitHub Secrets или у тимлида).
+   - В корне проекта создайте файл .env
+   - Добавьте переменную и вставьте в неё весь JSON:
    ```env
-   GOOGLE_APPLICATION_CREDENTIALS=src/main/resources/credentials.json
+   GOOGLE_APPLICATION_CREDENTIALS_JSON={"type": "service_account", ...}
    ```
+   - **Важно**: JSON должен быть в одну строку. Чтобы быстро это сделать в IDEA: выделите JSON и нажми Ctrl + Shift + J.
    
+
 2. Запуск
    - Через консоль
    ```bash

--- a/httpRequests/reviews-import.http
+++ b/httpRequests/reviews-import.http
@@ -1,0 +1,7 @@
+### Successful start - admin role
+POST http://localhost:8082/api/data-importer/start-guaranteed-reviews-import
+X-User-Roles: ADMIN
+
+### Not admin -> 403
+POST http://localhost:8082/api/data-importer/start-guaranteed-reviews-import
+X-User-Roles: STUDENT

--- a/httpRequests/reviews-import.http
+++ b/httpRequests/reviews-import.http
@@ -5,3 +5,11 @@ X-User-Roles: ADMIN
 ### Not admin -> 403
 POST http://localhost:8082/api/data-importer/start-guaranteed-reviews-import
 X-User-Roles: STUDENT
+
+### Missing roles header -> 403
+POST http://localhost:8082/api/data-importer/start-profiles-import
+
+### Multiple roles -> admin included
+POST http://localhost:8082/api/data-importer/start-profiles-import
+Content-Type: application/json
+X-User-Roles: STUDENT,ADMIN

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
@@ -10,11 +10,18 @@ import java.util.List;
 @ConfigurationProperties(prefix = "dataimporter")
 @Data
 public class DataImporterProperties {
+
     private String spreadsheetId;
+    private String mentorSpreadsheetId;
+
     private String sheetRangeTelegramAccounts;
     private String sheetRangeProjects;
+    private String sheetRangeReviews;
+
     private List<Long> adminIds;
+
     private String authServiceBaseUrl;
     private String profileServiceBaseUrl;
     private String projectServiceBaseUrl;
+    private String mentorServiceBaseUrl;
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Data
 public class DataImporterProperties {
 
-    private String spreadsheetId;
+    private String projectSpreadsheetId;
     private String mentorSpreadsheetId;
 
     private String sheetRangeTelegramAccounts;

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProfileImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProfileImportController.java
@@ -22,7 +22,7 @@ public class ProfileImportController implements ProfileImportApi {
 
     @Override
     @PostMapping("/start-profiles-import")
-    public ResponseEntity<?> startProfileImport(
+    public ResponseEntity<ImportStartResponseDto> startProfileImport(
             @RequestHeader(value = "X-User-Roles", required = false) List<String> roles
     ){
         RoleValidator.validateAdminRole(roles);

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProfileImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProfileImportController.java
@@ -1,11 +1,10 @@
 package com.itmentorcommunityplatform.dataimporter.controller;
 
 import com.itmentorcommunityplatform.dataimporter.controller.api.ProfileImportApi;
-import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
 import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
 import com.itmentorcommunityplatform.dataimporter.service.ProfileImportService;
+import com.itmentorcommunityplatform.dataimporter.validator.RoleValidator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -26,11 +25,10 @@ public class ProfileImportController implements ProfileImportApi {
     public ResponseEntity<?> startProfileImport(
             @RequestHeader(value = "X-User-Roles", required = false) List<String> roles
     ){
-        if (roles == null || roles.stream().noneMatch(r -> r.equalsIgnoreCase("ADMIN"))) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ErrorResponseDto("Access denied: missing ADMIN role in X-User-Roles header"));
-        }
+        RoleValidator.validateAdminRole(roles);
+
         profileImportService.startImportAsync();
+
         return ResponseEntity.ok(new ImportStartResponseDto("import_started"));
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProjectImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ProjectImportController.java
@@ -1,11 +1,10 @@
 package com.itmentorcommunityplatform.dataimporter.controller;
 
 import com.itmentorcommunityplatform.dataimporter.controller.api.ProjectImportApi;
-import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
 import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
 import com.itmentorcommunityplatform.dataimporter.service.ProjectImportService;
+import com.itmentorcommunityplatform.dataimporter.validator.RoleValidator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -25,11 +24,10 @@ public class ProjectImportController implements ProjectImportApi {
     public ResponseEntity<?> startProjectImport(
             @RequestHeader(value = "X-User-Roles", required = false) List<String> roles) {
 
-        if (roles == null || roles.stream().noneMatch(r -> r.equalsIgnoreCase("ADMIN"))) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(new ErrorResponseDto("Access denied: missing ADMIN role in X-User-Roles header"));
-        }
+        RoleValidator.validateAdminRole(roles);
+
         projectImportService.startImportAsync();
+
         return ResponseEntity.ok(new ImportStartResponseDto("import_started"));
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ReviewImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ReviewImportController.java
@@ -1,5 +1,6 @@
 package com.itmentorcommunityplatform.dataimporter.controller;
 
+import com.itmentorcommunityplatform.dataimporter.controller.api.GuaranteedReviewsImportApi;
 import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
 import com.itmentorcommunityplatform.dataimporter.service.ReviewImportService;
 import com.itmentorcommunityplatform.dataimporter.validator.RoleValidator;
@@ -15,7 +16,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/data-importer")
-public class ReviewImportController {
+public class ReviewImportController implements GuaranteedReviewsImportApi {
 
     private final ReviewImportService reviewImportService;
 

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ReviewImportController.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/ReviewImportController.java
@@ -1,8 +1,7 @@
 package com.itmentorcommunityplatform.dataimporter.controller;
 
-import com.itmentorcommunityplatform.dataimporter.controller.api.UserImportApi;
 import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
-import com.itmentorcommunityplatform.dataimporter.service.UserImportService;
+import com.itmentorcommunityplatform.dataimporter.service.ReviewImportService;
 import com.itmentorcommunityplatform.dataimporter.validator.RoleValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,20 +13,19 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/data-importer")
 @RequiredArgsConstructor
-public class UserImportController implements UserImportApi {
+@RequestMapping("/api/data-importer")
+public class ReviewImportController {
 
-    private final UserImportService importService;
+    private final ReviewImportService reviewImportService;
 
-    @Override
-    @PostMapping("/start-users-import")
-    public ResponseEntity<?> startUsersImport(
-            @RequestHeader(value = "X-User-Roles", required = false) List<String> roles) {
-
+    @PostMapping("/start-guaranteed-reviews-import")
+    public ResponseEntity<?> startGuaranteedReviewsImport(
+            @RequestHeader(value = "X-User-Roles", required = false) List<String> roles
+    ) {
         RoleValidator.validateAdminRole(roles);
 
-        importService.startImportAsync();
+        reviewImportService.startImportAsync();
 
         return ResponseEntity.ok(new ImportStartResponseDto("import_started"));
     }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/api/GuaranteedReviewsImportApi.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/controller/api/GuaranteedReviewsImportApi.java
@@ -1,0 +1,60 @@
+package com.itmentorcommunityplatform.dataimporter.controller.api;
+
+import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
+import com.itmentorcommunityplatform.dataimporter.dto.response.ImportStartResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Guaranteed Reviews Import", description = "API for managing guaranteed reviews imports")
+public interface GuaranteedReviewsImportApi {
+
+    @Operation(
+            summary = "Starting guaranteed reviews import",
+            description = "Asynchronously starts the process of reading the Google Spreadsheet and updating prices for guaranteed reviews in the Mentor Service."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Import started successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ImportStartResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access is denied (missing ADMIN role)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponseDto.class)
+                    )
+            )
+    })
+    ResponseEntity<?> startGuaranteedReviewsImport(
+            @Parameter(
+                    name = "X-User-Roles",
+                    in = ParameterIn.HEADER,
+                    description = "The list of user roles. The ADMIN role is required.",
+                    required = true,
+                    schema = @Schema(type = "array", implementation = String.class, example = "[\"ADMIN\"]")
+            )
+            List<String> roles
+    );
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/request/GuaranteedReviewRequestDto.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/dto/request/GuaranteedReviewRequestDto.java
@@ -1,0 +1,25 @@
+package com.itmentorcommunityplatform.dataimporter.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class GuaranteedReviewRequestDto {
+
+    @JsonProperty("telegram_url")
+    private String telegramUrl;
+
+    private String language;
+
+    @JsonProperty("project_type")
+    private String projectType;
+
+    @JsonProperty("price_usd")
+    private Integer priceUsd;
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/exception/GlobalExceptionHandler.java
@@ -1,18 +1,30 @@
 package com.itmentorcommunityplatform.dataimporter.exception;
 
 import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorResponseDto> handleResponseStatusException(ResponseStatusException ex) {
+        log.error("Unhandled exception occurred: ", ex);
         return ResponseEntity
                 .status(ex.getStatusCode())
                 .body(new ErrorResponseDto(ex.getReason()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleAllUncaughtExceptions(Exception ex) {
+        log.error("Unhandled exception occurred: ", ex);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponseDto("An unexpected error occurred. Please try again later."));
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.itmentorcommunityplatform.dataimporter.exception;
+
+import com.itmentorcommunityplatform.dataimporter.dto.response.ErrorResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponseDto> handleResponseStatusException(ResponseStatusException ex) {
+        return ResponseEntity
+                .status(ex.getStatusCode())
+                .body(new ErrorResponseDto(ex.getReason()));
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -31,9 +30,6 @@ public class GoogleSheetsClient {
     private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
     private final DataImporterProperties props;
-
-    @Value("${google.credentials.path:}")
-    private String credentialsPath;
 
     @Value("${google.credentials.json:}")
     private String credentialsJson;
@@ -84,12 +80,6 @@ public class GoogleSheetsClient {
     }
 
     private GoogleCredentials loadCredentials() throws IOException {
-        if (!credentialsPath.isBlank()) {
-            log.info("Loading Google credentials from file: {}", credentialsPath);
-            try (FileInputStream in = new FileInputStream(credentialsPath)) {
-                return GoogleCredentials.fromStream(in);
-            }
-        }
         if (!credentialsJson.isBlank()) {
             log.info("Loading Google credentials from JSON config property");
             return GoogleCredentials.fromStream(

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
@@ -57,12 +57,11 @@ public class GoogleSheetsClient {
         }
     }
 
-    public List<List<Object>> readSheet(String spreedSheetRange) throws IOException {
-        String spreadsheetId = props.getSpreadsheetId();
-        String range = spreedSheetRange;
-        log.debug("Reading Google Sheet: id={}, range={}", spreadsheetId, range);
+    public List<List<Object>> readSheet(String projectSpreedSheetRange) throws IOException {
+        String projectSpreadsheetId = props.getProjectSpreadsheetId();
+        log.debug("Reading Google Sheet: id={}, range={}", projectSpreadsheetId, projectSpreedSheetRange);
         ValueRange response = sheetsService.spreadsheets().values()
-                .get(spreadsheetId, range)
+                .get(projectSpreadsheetId, projectSpreedSheetRange)
                 .execute();
         List<List<Object>> values = response.getValues();
         return values == null ? Collections.emptyList() : values;
@@ -96,7 +95,7 @@ public class GoogleSheetsClient {
         try {
             sheetsService.spreadsheets()
                     .values()
-                    .append(props.getSpreadsheetId(), props.getSheetRangeProjects(), range)
+                    .append(props.getProjectSpreadsheetId(), props.getSheetRangeProjects(), range)
                     .setValueInputOption("USER_ENTERED")
                     .execute();
 
@@ -104,7 +103,7 @@ public class GoogleSheetsClient {
 
         } catch (Exception e) {
             log.error("[Sheets] Failed to append row spreadsheetId={}, range={}, reason={} ",
-                    props.getSpreadsheetId(),
+                    props.getProjectSpreadsheetId(),
                     props.getSheetRangeProjects(),
                     e.getMessage());
 

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/google/GoogleSheetsClient.java
@@ -9,7 +9,6 @@ import com.google.api.services.sheets.v4.model.ValueRange;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
-import com.itmentorcommunityplatform.dataimporter.dto.event.ProjectCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -69,6 +68,17 @@ public class GoogleSheetsClient {
         ValueRange response = sheetsService.spreadsheets().values()
                 .get(spreadsheetId, range)
                 .execute();
+        List<List<Object>> values = response.getValues();
+        return values == null ? Collections.emptyList() : values;
+    }
+
+    public List<List<Object>> readSheet(String spreadsheetId, String range) throws IOException {
+        log.debug("Reading Google Sheet: id={}, range={}", spreadsheetId, range);
+
+        ValueRange response = sheetsService.spreadsheets().values()
+                .get(spreadsheetId, range)
+                .execute();
+
         List<List<Object>> values = response.getValues();
         return values == null ? Collections.emptyList() : values;
     }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/httpclient/ServiceHttpClient.java
@@ -1,6 +1,7 @@
 package com.itmentorcommunityplatform.dataimporter.httpclient;
 
 import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
+import com.itmentorcommunityplatform.dataimporter.dto.request.GuaranteedReviewRequestDto;
 import com.itmentorcommunityplatform.dataimporter.dto.request.ProfileUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.dto.request.ProjectUpsertRequestDto;
 import com.itmentorcommunityplatform.dataimporter.dto.request.UserUpsertRequestDto;
@@ -113,10 +114,58 @@ public class ServiceHttpClient {
             log.error("ProjectService returned error. status={}, body={}, telegramId={}, roadmapProject={}",
                     wcre.getStatusCode().value(), wcre.getResponseBodyAsString(), requestDto.telegramUserId(), requestDto.roadmapProject());
             throw wcre;
-        }catch (Exception ex) {
+        } catch (Exception ex) {
             log.error("Failed upsert project in ProjectService: authorTelegramUserId={}, roadmapProject={}",
                     requestDto.authorTelegramUserId(), requestDto.roadmapProject());
         }
+    }
 
+    public void upsertGuaranteedReview(GuaranteedReviewRequestDto requestDto, Long telegramUserId) {
+        String uri = props.getMentorServiceBaseUrl() + "/api/mentor/internal/guaranteed-review";
+
+        try {
+            webClient.post()
+                    .uri(uri)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .header("X-Telegram-User-Id", String.valueOf(telegramUserId))
+                    .bodyValue(requestDto)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block(Duration.ofSeconds(10));
+
+            log.info("Successfully upserted guaranteed review: mentorUrl={}, language={}, projectType={}",
+                    requestDto.getTelegramUrl(), requestDto.getLanguage(), requestDto.getProjectType());
+
+        } catch (WebClientResponseException webClientEx) {
+            log.error("Mentor Service returned error. status={}, body={}, mentorUrl={}",
+                    webClientEx.getStatusCode().value(), webClientEx.getResponseBodyAsString(), requestDto.getTelegramUrl());
+            throw webClientEx;
+        } catch (Exception ex) {
+            log.error("Failed to call Mentor Service for mentorUrl={}, error={}",
+                    requestDto.getTelegramUrl(), ex.getMessage());
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public Long getTelegramUserIdByUrl(String telegramUrl) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(props.getProfileServiceBaseUrl())
+                .path("/api/profile/internal/profile/by-telegram-url")
+                .queryParam("url", telegramUrl)
+                .toUriString();
+
+        try {
+            ProfileByGithubResponseDto response = webClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(ProfileByGithubResponseDto.class)
+                    .block(Duration.ofSeconds(5));
+
+            return response != null ? response.telegramUserId() : null;
+
+        } catch (Exception ex) {
+            log.error("Failed to find profile for telegramUrl={}, error={}", telegramUrl, ex.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/model/RoadmapProjectType.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/model/RoadmapProjectType.java
@@ -1,0 +1,27 @@
+package com.itmentorcommunityplatform.dataimporter.model;
+
+public enum RoadmapProjectType {
+    HANGMAN("Виселица"),
+    SIMULATION("Симуляция"),
+    CURRENCY_EXCHANGE("Обмен валют"),
+    TENNIS_SCOREBOARD("Теннисное табло"),
+    WEATHER_VIEWER("Погода"),
+    CLOUD_FILE_STORAGE("Облачное хранилище файлов"),
+    TASK_TRACKER("Планировщик задач"),
+    OTHER("");
+
+    private final String russianName;
+
+    RoadmapProjectType(String russianName) {
+        this.russianName = russianName;
+    }
+
+    public static RoadmapProjectType fromRussianName(String text) {
+        for (RoadmapProjectType type : RoadmapProjectType.values()) {
+            if (type.russianName.equalsIgnoreCase(text.trim())) {
+                return type;
+            }
+        }
+        return OTHER;
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ProjectImportService.java
@@ -130,7 +130,7 @@ public class ProjectImportService {
         }
     }
 
-    private String getTelegramUsernameFromUrl(String url){
+    private String getTelegramUsernameFromUrl(String url) {
         return url.substring(url.lastIndexOf('/'));
     }
 
@@ -157,5 +157,4 @@ public class ProjectImportService {
     public void shutdown() {
         executor.shutdownNow();
     }
-
 }

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
@@ -119,7 +119,6 @@ public class ReviewImportService {
         return "https://t.me/" + telegram.substring(telegram.indexOf("@") + 1).trim();
     }
 
-
     private Integer parsePrice(String priceRaw) {
         if (priceRaw == null || priceRaw.isBlank()) {
             return 0;

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -41,6 +43,8 @@ public class ReviewImportService {
                 return;
             }
 
+            Map<String, Long> mentorIdCache = new HashMap<>();
+
             String currentProjectName = "";
             int totalImportedCount = 0;
 
@@ -50,13 +54,13 @@ public class ReviewImportService {
                 }
 
                 String projectInRow = row.size() > 0 ? String.valueOf(row.get(0)).trim() : "";
-                if (!projectInRow.isEmpty()) {
-                    currentProjectName = projectInRow;
-                }
-
                 String telegramRow = row.size() > 1 ? String.valueOf(row.get(1)).trim() : "";
                 String languagesRaw = row.size() > 2 ? String.valueOf(row.get(2)).trim() : "";
                 String priceRaw = row.size() > 3 ? String.valueOf(row.get(3)).trim() : "";
+
+                if (!projectInRow.isEmpty()) {
+                    currentProjectName = projectInRow;
+                }
 
                 String telegramUrl = tgUrlFromTgName(telegramRow);
 
@@ -64,10 +68,14 @@ public class ReviewImportService {
                     continue;
                 }
 
-                Long mentorTelegramId = httpClient.getTelegramUserIdByUrl(telegramUrl);
+                Long mentorTelegramId = mentorIdCache.computeIfAbsent(telegramUrl, url -> {
+                    log.debug("Cache miss for {}, fetching ID from Profile Service", url);
+                    return httpClient.getTelegramUserIdByUrl(url);
+                });
 
                 if (mentorTelegramId == null) {
                     log.warn("Skip: Mentor with url {} not found in Profile Service", telegramUrl);
+                    mentorIdCache.remove(telegramUrl);
                     continue;
                 }
 

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/ReviewImportService.java
@@ -1,0 +1,122 @@
+package com.itmentorcommunityplatform.dataimporter.service;
+
+import com.itmentorcommunityplatform.dataimporter.config.DataImporterProperties;
+import com.itmentorcommunityplatform.dataimporter.dto.request.GuaranteedReviewRequestDto;
+import com.itmentorcommunityplatform.dataimporter.google.GoogleSheetsClient;
+import com.itmentorcommunityplatform.dataimporter.httpclient.ServiceHttpClient;
+import com.itmentorcommunityplatform.dataimporter.model.RoadmapProjectType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewImportService {
+
+    private final GoogleSheetsClient googleSheetsClient;
+    private final DataImporterProperties properties;
+    private final ServiceHttpClient httpClient;
+
+    private final ExecutorService executor =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, "review-import-thread"));
+
+    public void startImportAsync() {
+        executor.submit(this::doImport);
+    }
+
+    private void doImport() {
+        log.info("Starting guaranteed reviews import...");
+        try {
+            List<List<Object>> rows = googleSheetsClient.readSheet(
+                    properties.getMentorSpreadsheetId(),
+                    properties.getSheetRangeReviews()
+            );
+            if (rows == null || rows.isEmpty()) {
+                log.warn("No data found in the specified range.");
+                return;
+            }
+
+            String currentProjectName = "";
+            int totalImportedCount = 0;
+
+            for (List<Object> row : rows) {
+                if (row == null || row.isEmpty()) {
+                    continue;
+                }
+
+                String projectInRow = row.size() > 0 ? String.valueOf(row.get(0)).trim() : "";
+                if (!projectInRow.isEmpty()) {
+                    currentProjectName = projectInRow;
+                }
+
+                String telegramRow = row.size() > 1 ? String.valueOf(row.get(1)).trim() : "";
+                String languagesRaw = row.size() > 2 ? String.valueOf(row.get(2)).trim() : "";
+                String priceRaw = row.size() > 3 ? String.valueOf(row.get(3)).trim() : "";
+
+                String telegramUrl = tgUrlFromTgName(telegramRow);
+
+                if (telegramUrl.isEmpty() || languagesRaw.isEmpty()) {
+                    continue;
+                }
+
+                Long mentorTelegramId = httpClient.getTelegramUserIdByUrl(telegramUrl);
+
+                if (mentorTelegramId == null) {
+                    log.warn("Skip: Mentor with url {} not found in Profile Service", telegramUrl);
+                    continue;
+                }
+
+                int price = parsePrice(priceRaw);
+                String[] languages = languagesRaw.split(",");
+
+                for (String lang : languages) {
+                    String cleanLang = lang.trim();
+                    if (cleanLang.isEmpty()) {
+                        continue;
+                    }
+
+                    try {
+                        String projectType = RoadmapProjectType.fromRussianName(currentProjectName).name();
+
+                        log.info("Importing: Project={}, Mentor={}, Language={}, Price={}",
+                                projectType, telegramUrl, cleanLang, priceRaw);
+
+                        httpClient.upsertGuaranteedReview(new GuaranteedReviewRequestDto(
+                                telegramUrl, cleanLang, projectType, price
+                        ), mentorTelegramId);
+
+                        totalImportedCount++;
+                    } catch (Exception e) {
+                        log.error("Failed to import review for mentor {} (lang: {}): {}",
+                                telegramUrl, cleanLang, e.getMessage());
+                    }
+                }
+            }
+            log.info("Guaranteed reviews import finished. Total successfully imported: {}", totalImportedCount);
+        } catch (Exception e) {
+            log.error("Critical error during guaranteed reviews import", e);
+        }
+    }
+
+    private String tgUrlFromTgName(String telegram) {
+        if (telegram == null || !telegram.contains("@")) {
+            return "";
+        }
+
+        return "https://t.me/" + telegram.substring(telegram.indexOf("@") + 1).trim();
+    }
+
+
+    private Integer parsePrice(String priceRaw) {
+        if (priceRaw == null || priceRaw.isBlank()) {
+            return 0;
+        }
+        String cleanPrice = priceRaw.replaceAll("[^0-9]", "");
+        return cleanPrice.isEmpty() ? 0 : Integer.parseInt(cleanPrice);
+    }
+}

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/validator/RoleValidator.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/validator/RoleValidator.java
@@ -1,0 +1,15 @@
+package com.itmentorcommunityplatform.dataimporter.validator;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+public class RoleValidator {
+
+    public static void validateAdminRole(List<String> roles) {
+        if (roles == null || roles.stream().noneMatch(r -> r.equalsIgnoreCase("ADMIN"))) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied: missing ADMIN role");
+        }
+    }
+}

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -9,7 +9,7 @@ spring:
 
 dataimporter:
   spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
-  mentor-spreadsheet-id: "1DkIIcE6oUtcK9jjfrOyUgatb6DIxL5GXEn3kvUp4Lms"
+  mentor-spreadsheet-id: "1oP6a4wcItGOlbD6OYpV-u5Z1jFJAhLEq-llOZSHP414" # локальная таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
   sheet-range-reviews: "B7:E"

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -8,7 +8,7 @@ spring:
 
 
 dataimporter:
-  spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  project-spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
   mentor-spreadsheet-id: "1oP6a4wcItGOlbD6OYpV-u5Z1jFJAhLEq-llOZSHP414" # локальная таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -9,12 +9,15 @@ spring:
 
 dataimporter:
   spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  mentor-spreadsheet-id: "1DkIIcE6oUtcK9jjfrOyUgatb6DIxL5GXEn3kvUp4Lms"
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
+  sheet-range-reviews: "B7:E"
   admin-ids: [ ]
   auth-service-base-url: "http://localhost:8081"
   profile-service-base-url: "http://localhost:8083"
   project-service-base-url: "http://localhost:8084"
+  mentor-service-base-url: "http://localhost:8085"
 
 
 server:

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -11,12 +11,15 @@ server:
 
 dataimporter:
   spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  mentor-spreadsheet-id: "1oP6a4wcItGOlbD6OYpV-u5Z1jFJAhLEq-llOZSHP414" # локальная таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
+  sheet-range-reviews: "B7:E"
   admin-ids: []
   auth-service-base-url: "http://auth-service:8080"
   profile-service-base-url: "http://profile-service:8080"
   project-service-base-url: "http://project-service:8080"
+  mentor-service-base-url: "http://mentor-service:8085"
 
 management:
   endpoint:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -12,12 +12,15 @@ server:
 
 dataimporter:
   spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  mentor-spreadsheet-id: "1DkIIcE6oUtcK9jjfrOyUgatb6DIxL5GXEn3kvUp4Lms" # продовая таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
+  sheet-range-reviews: "B7:E"
   admin-ids: []
   auth-service-base-url: "http://auth-service:8080"
   profile-service-base-url: "http://profile-service:8080"
   project-service-base-url: "http://project-service:8080"
+  mentor-service-base-url: "http://mentor-service:8085"
 
 
 management:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,5 +37,5 @@ management:
 
 google:
   credentials:
-    path: ${GOOGLE_APPLICATION_CREDENTIALS:}
+    path: ${GOOGLE_APPLICATION_CREDENTIALS:src/main/resources/credentials.json}
     json: ${GOOGLE_APPLICATION_CREDENTIALS_JSON:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: data-importer
+  config:
+    import: optional:file:.env[.properties]
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
@@ -37,5 +39,4 @@ management:
 
 google:
   credentials:
-    path: ${GOOGLE_APPLICATION_CREDENTIALS:src/main/resources/credentials.json}
     json: ${GOOGLE_APPLICATION_CREDENTIALS_JSON:}


### PR DESCRIPTION
- `POST /api/data-importer/start-guaranteed-reviews-import`
- Проверка роли ADMIN по заголовку `X-User-Roles`
- Импорт запускается в отдельном потоке (SingleThreadExecutor)
- Логика:
    - Парсинг Google таблицы.
    - Поиск telegramId через Profile Service (добавлен in-memory кэш что бы меньше бегать в БД)
    - Сохранение данных в Mentor Service (`POST /api/mentor/internal/guaranteed-review`)
- настроен доступ к тестовой таблице в  (`ide`, `local-stack` ). У `staging` - продовая
- Добавлены ручные .http сценарии

P.S: Я только при создании pull resuest заметил твои слова 'Парсинг таблицы происходит асинхронно в пуле потоков из одного потока', а я сделал асинхронный весь импорт, пока что так отправил, если что исправлю.