### PR TITLE
fix: rename spreadsheet property for local-stack and staging

### DIFF
--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -10,7 +10,7 @@ server:
   port: 8080
 
 dataimporter:
-  spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  project-spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
   mentor-spreadsheet-id: "1oP6a4wcItGOlbD6OYpV-u5Z1jFJAhLEq-llOZSHP414" # локальная таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -9,9 +9,8 @@ spring:
 server:
   port: 8080
 
-
 dataimporter:
-  spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
+  project-spreadsheet-id: "1Ya7J-nsc2m4D9MuiDbauypL7yWocHGoJj9P7tVimxp8"
   mentor-spreadsheet-id: "1DkIIcE6oUtcK9jjfrOyUgatb6DIxL5GXEn3kvUp4Lms" # продовая таблца
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
@@ -21,7 +20,6 @@ dataimporter:
   profile-service-base-url: "http://profile-service:8080"
   project-service-base-url: "http://project-service:8080"
   mentor-service-base-url: "http://mentor-service:8085"
-
 
 management:
   endpoint:


### PR DESCRIPTION
Заменил dataimporter.spreadsheet-id на dataimporter.project-spreadsheet-id для конфигураций профилей local-stack и staging.

Ручной тест: приложение стартует корректно, запускается с профилем: local-stack (через сборку локального докер образа), данные теперь импортируются.