### PR TITLE
fix: remove admin ids config and default imported users to STUDENT

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/config/DataImporterProperties.java
@@ -4,8 +4,6 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @Configuration
 @ConfigurationProperties(prefix = "dataimporter")
 @Data
@@ -17,8 +15,6 @@ public class DataImporterProperties {
     private String sheetRangeTelegramAccounts;
     private String sheetRangeProjects;
     private String sheetRangeReviews;
-
-    private List<Long> adminIds;
 
     private String authServiceBaseUrl;
     private String profileServiceBaseUrl;

--- a/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
+++ b/src/main/java/com/itmentorcommunityplatform/dataimporter/service/UserImportService.java
@@ -77,10 +77,7 @@ public class UserImportService {
                     skippedDuplicates++;
                     continue;
                 }
-                boolean isAdmin = properties.getAdminIds() != null && properties.getAdminIds().contains(tgId);
-                List<String> rolesToSend = isAdmin
-                        ? List.of(UserRole.ADMIN.name(), UserRole.STUDENT.name())
-                        : List.of(UserRole.STUDENT.name());
+                List<String> rolesToSend = List.of(UserRole.STUDENT.name());
                 UserUpsertRequestDto req = new UserUpsertRequestDto(tgId, rolesToSend);
                 try {
                     httpClient.upsertUser(req);

--- a/src/main/resources/application-ide.yml
+++ b/src/main/resources/application-ide.yml
@@ -13,7 +13,6 @@ dataimporter:
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
   sheet-range-reviews: "B7:E"
-  admin-ids: [ ]
   auth-service-base-url: "http://localhost:8081"
   profile-service-base-url: "http://localhost:8083"
   project-service-base-url: "http://localhost:8084"

--- a/src/main/resources/application-local-stack.yml
+++ b/src/main/resources/application-local-stack.yml
@@ -15,7 +15,6 @@ dataimporter:
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
   sheet-range-reviews: "B7:E"
-  admin-ids: []
   auth-service-base-url: "http://auth-service:8080"
   profile-service-base-url: "http://profile-service:8080"
   project-service-base-url: "http://project-service:8080"

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -21,7 +21,6 @@ dataimporter:
   sheet-range-telegram-accounts: "Telegram аккаунты студентов!A2:C"
   sheet-range-projects: "Projects!A3:I"
   sheet-range-reviews: "B7:E"
-  admin-ids: []
   auth-service-base-url: "http://auth-service:8080"
   profile-service-base-url: "http://profile-service:8080"
   project-service-base-url: "http://project-service:8080"


### PR DESCRIPTION
Удалил из properties-классов, конфигураций приложения установку id админов.
При импорте пользователей, по умолчанию проставляется роль STUDENT